### PR TITLE
no output type: null -> none

### DIFF
--- a/schema/actions/README.md
+++ b/schema/actions/README.md
@@ -218,7 +218,7 @@ An `action` **MUST** define it's `output`.
 </p>
 </json-table>
 
-> <small>If there is no output then it must use `output: null` explicitly.</small>
+> <small>If there is no output then it must use `output: none` explicitly.</small>
 
 ### Properties
 
@@ -256,7 +256,7 @@ actions:
     arguments:
       tweetid:
         type: int
-    output: null
+    output: none
 
   stream:
     events:

--- a/schema/actions/README.md
+++ b/schema/actions/README.md
@@ -218,7 +218,9 @@ An `action` **MUST** define it's `output`.
 </p>
 </json-table>
 
-> <small>If there is no output then it must use `output: none` explicitly.</small>
+> <small>If there is no output then it must use `output: none` explicitly.
+> `output: none` can also be used if the output should be ignored (e.g. for debug output).
+> </small>
 
 ### Properties
 


### PR DESCRIPTION
`null` comes from JSON, but the specification is in YAML.
Hence, `none` is a more natural fit.