### PR TITLE
Allow 'default' for environment variables

### DIFF
--- a/schema/environment/README.md
+++ b/schema/environment/README.md
@@ -31,7 +31,8 @@ Each environment variable under `environment` may have the following information
     },
     "pattern": "Validations for strings in a regular expression format.",
     "required": "Whether this variable is required or not. Default is `false`",
-    "sensitive": "Set this to true if the environment variable is considered secret/private to inform the platform to encrypt the variable. Default is `false`",
+    "default": "Optional default value for this environment variable. This value will be used if this variable wasn't provided to the service. Default values can't be set if this variable is set as `required`.",
+    "sensitive": "Set this to `true` if the environment variable is considered secret/private to inform the platform to encrypt the variable. Default is `false`",
     "help": "Description of how the user can produce this variable or details on why they need to provide it"
 }
 </p>


### PR DESCRIPTION
This allows for an explicit way to provide defaults for two reasons:
- better and explicit documentation (currently one has to state default values in the help text)
- better configuration introspection in e.g. the dashboard (specified default values allow to user an easy way to say what all config variables are and to which values they are set).