### PR TITLE
Allow optional object properties

### DIFF
--- a/schema/actions/README.md
+++ b/schema/actions/README.md
@@ -283,6 +283,26 @@ actions:
                 type: string
 ```
 
+Objects may have optional properties:
+
+```yaml{6}
+actions:
+  create:
+    arguments:
+      user:
+        type: object
+        properties:
+          name:
+            type: string
+          location:
+            type: object
+            properties:
+              street:
+                type: string
+                required: false
+              postcode:
+                type: string
+```
 
 ## Output
 


### PR DESCRIPTION
Fixes https://github.com/microservices/microservice.guide/issues/138. I re-used the existing keyword `required` to avoid confusion for users.